### PR TITLE
Fix RuntimeError caused by StopIteration

### DIFF
--- a/git_source_track/git_log.py
+++ b/git_source_track/git_log.py
@@ -37,10 +37,9 @@ def _get_commits(fname, rev_range):
     args.append(fname)
     it = sh.git(*args, _tty_out=False, _iter=True)
     
-    while True:
-        l1 = next(it).strip().split()
-        next(it)
-        l2 = next(it).strip()
+    for l1, _, l2 in zip(it, it, it):
+        l1 = l1.strip().split()
+        l2 = l2.strip()
         
         yield int(l1[0]), l1[1], l2
 


### PR DESCRIPTION
```pytb
Traceback (most recent call last):
  File "git_source_track/git_log.py", line 41, in _get_commits
    l1 = next(it).strip().split()
  File "/usr/lib/python3.7/site-packages/sh.py", line 865, in next
    raise StopIteration()
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "~/.local/bin/git-source-track", line 11, in <module>
    load_entry_point('git-source-track', 'console_scripts', 'git-source-track')()
  File "git_source_track/cmd.py", line 639, in main
    action_diff(cfg, args)
  File "git_source_track/cmd.py", line 313, in action_diff
    git_log(cfg, info.orig_fnames, revs)
  File "git_source_track/git_log.py", line 79, in git_log
    commit_data += _get_commits(fname, rev_range)
RuntimeError: generator raised StopIteration
```